### PR TITLE
ptah: Use crate::MARKER_* for serializing bools

### DIFF
--- a/lib/ptah/src/ser.rs
+++ b/lib/ptah/src/ser.rs
@@ -25,8 +25,8 @@ where
 
     fn serialize_bool(self, value: bool) -> Result<Self::Ok> {
         match value {
-            false => self.writer.write(&[0x00]),
-            true => self.writer.write(&[0x01]),
+            false => self.writer.write(&[crate::MARKER_FALSE]),
+            true => self.writer.write(&[crate::MARKER_TRUE]),
         }
     }
 


### PR DESCRIPTION
Previously, only `de.rs` used the `bool` markers for true and false.

This isn't important, but I noticed the discrepancy, so might as well fix it.